### PR TITLE
decompilation issues

### DIFF
--- a/src/main/java/com/neva/felix/webconsole/plugins/search/core/OsgiExplorer.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/core/OsgiExplorer.java
@@ -129,8 +129,16 @@ public class OsgiExplorer {
 					settings.setForceExplicitImports(true);
 					settings.setForceExplicitTypeArguments(true);
 
-					Decompiler.decompile(path, new PlainTextOutput(writer), settings);
+					try {
+						Decompiler.decompile(path, new PlainTextOutput(writer), settings);
+					} catch (Throwable throwable) {
+						LOG.error("logging throwable for path: '{}'", path, throwable);
+						throw new RuntimeException("Troubles while decompiling: '"
+														+ path + "'", throwable);
+					}
 					stream.flush();
+				} catch (Exception e) {
+					LOG.error("catch me: '{}'", path, e);
 				}
 			} finally {
 				stream.close();


### PR DESCRIPTION
I have found something.. :) I have run the felix with:

```
java -jar -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=30303 -Djava.io.tmpdir=./io_tmp -Dlogback.configurationFile=./conf/logback-dev.xml bin\felix.jar
```

and there it is:
```
22:14:57.052 ERROR com.neva.felix.webconsole.plugins.search.core.OsgiExplorer:135 - logging throwable for path: 'org/apache/felix/eventadmin/impl/Activator'
java.lang.NoClassDefFoundError: sun/misc/Unsafe
	at com.strobel.compilerservices.RuntimeHelpers.getUnsafeInstance(RuntimeHelpers.java:55)
	at com.strobel.compilerservices.RuntimeHelpers.ensureClassInitialized(RuntimeHelpers.java:31)
	at com.strobel.assembler.metadata.MetadataSystem.<clinit>(MetadataSystem.java:147)
	at com.strobel.decompiler.Decompiler.decompile(Decompiler.java:34)
	at com.neva.felix.webconsole.plugins.search.core.OsgiExplorer.decompileClass(OsgiExplorer.java:133)

```

Please find logback configuration and log files in this archive:
[2017-02-27-logs.zip](https://github.com/neva-dev/felix-search-webconsole-plugin/files/805164/2017-02-27-logs.zip)

I will stop invastigation here, as it is getting late.. ;p