### PR TITLE
Bump up procyon libraries - fixes #18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,6 @@
         <felix.url>http://localhost:8080/system/console</felix.url>
         <felix.user>admin</felix.user>
         <felix.password>admin</felix.password>
-        <procyon.version>0.5.32</procyon.version>
+        <procyon.version>0.5.36</procyon.version>
     </properties>
 </project>


### PR DESCRIPTION
After bumping up procyon libraries, the issue #18 does not occur anymore. It is also backward compatible (checked on java 8).