### PR TITLE
Support jd-core decompiler with partial line number output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     </profiles>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <felix.url>http://localhost:4502/system/console</felix.url>
+        <felix.url>http://localhost:8080/system/console</felix.url>
         <felix.user>admin</felix.user>
         <felix.password>admin</felix.password>
         <jd-core.version>1.1.3</jd-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.neva.felix</groupId>
     <artifactId>search-webconsole-plugin</artifactId>
     <packaging>bundle</packaging>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1-jd-SNAPSHOT</version>
     <name>search-webconsole-plugin</name>
     <description>Search everywhere plugin for Apache Felix Web Console</description>
     <inceptionYear>2017</inceptionYear>
@@ -62,6 +63,27 @@
             <url>https://api.bintray.com/maven/neva-dev/maven-public/felix-search-webconsole-plugin/;publish=1;override=1</url>
         </repository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray-plugins</name>
+            <url>https://jcenter.bintray.com</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
         <resources>
@@ -118,9 +140,7 @@
                             guava,
                             commons-lang3,
                             commons-io,
-                            procyon-core,
-                            procyon-reflection,
-                            procyon-compilertools
+                            jd-core
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -158,6 +178,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <source>8</source>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                 </configuration>
             </plugin>
@@ -207,21 +228,9 @@
 
         <!-- Java decompiler -->
         <dependency>
-            <groupId>org.bitbucket.mstrobel</groupId>
-            <artifactId>procyon-core</artifactId>
-            <version>${procyon.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.bitbucket.mstrobel</groupId>
-            <artifactId>procyon-reflection</artifactId>
-            <version>${procyon.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.bitbucket.mstrobel</groupId>
-            <artifactId>procyon-compilertools</artifactId>
-            <version>${procyon.version}</version>
+            <groupId>org.jd</groupId>
+            <artifactId>jd-core</artifactId>
+            <version>${jd-core.version}</version>
         </dependency>
 
         <!-- Embedded -->
@@ -269,9 +278,9 @@
     </profiles>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <felix.url>http://localhost:8080/system/console</felix.url>
+        <felix.url>http://localhost:4502/system/console</felix.url>
         <felix.user>admin</felix.user>
         <felix.password>admin</felix.password>
-        <procyon.version>0.5.36</procyon.version>
+        <jd-core.version>1.1.3</jd-core.version>
     </properties>
 </project>

--- a/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/Buffer.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/Buffer.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 
 /**
  * @author Mike Strobel
+ * Original code found at https://github.com/mstrobel/procyon.git
+ * com.strobel.assembler.metadata.Buffer
  */
 public class Buffer {
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];

--- a/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/Buffer.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/Buffer.java
@@ -1,0 +1,385 @@
+package com.neva.felix.webconsole.plugins.search.decompiler.jd;
+
+import java.nio.BufferUnderflowException;
+import java.util.Arrays;
+
+/**
+ * @author Mike Strobel
+ */
+public class Buffer {
+    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    private final static int DEFAULT_SIZE = 64;
+
+    private byte[] _data;
+    private int _length;
+    private int _position;
+
+    public Buffer() {
+        _data = new byte[DEFAULT_SIZE];
+        _length = DEFAULT_SIZE;
+    }
+
+    public Buffer(final byte[] data) {
+        _data = data;
+        _length = data.length;
+    }
+
+    public Buffer(final int initialSize) {
+        _data = new byte[initialSize];
+        _length = initialSize;
+    }
+
+    public int size() {
+        return _length;
+    }
+
+    public void flip() {
+        _length = _position;
+        _position = 0;
+    }
+
+    public int position() {
+        return _position;
+    }
+
+    public void position(final int position) {
+        if (position > _length) {
+            throw new BufferUnderflowException();
+        }
+        _position = position;
+    }
+
+    public void advance(final int length) {
+        if (_position + length > _length) {
+            _position = _length;
+            throw new BufferUnderflowException();
+        }
+        _position += length;
+    }
+
+    public void reset() {
+        reset(DEFAULT_SIZE);
+    }
+
+    public void reset(final int initialSize) {
+        if (initialSize == 0) {
+            _data = EMPTY_BYTE_ARRAY;
+        }
+        else if (initialSize > _data.length || initialSize < _data.length / 4) {
+            _data = new byte[initialSize];
+        }
+        _length = initialSize;
+        _position = 0;
+    }
+
+    public byte[] array() {
+        return _data;
+    }
+
+    public int read(final byte[] buffer, final int offset, final int length) {
+        if (buffer == null) {
+            throw new NullPointerException();
+        }
+
+        if (offset < 0 || length < 0 || length > buffer.length - offset) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        if (_position >= _length) {
+            return -1;
+        }
+
+        final int available = _length - _position;
+        final int actualLength = Math.min(length, available);
+
+        if (actualLength <= 0) {
+            return 0;
+        }
+
+        System.arraycopy(_data, _position, buffer, offset, actualLength);
+
+        _position += actualLength;
+
+        return actualLength;
+    }
+
+    public String readUtf8() {
+        final int utfLength = readUnsignedShort();
+        final byte[] byteBuffer = new byte[utfLength];
+        final char[] charBuffer = new char[utfLength];
+
+        int ch, ch2, ch3;
+        int count = 0;
+        int charactersRead = 0;
+
+        read(byteBuffer, 0, utfLength);
+
+        while (count < utfLength) {
+            ch = (int) byteBuffer[count] & 0xFF;
+            if (ch > 127) {
+                break;
+            }
+            count++;
+            charBuffer[charactersRead++] = (char) ch;
+        }
+
+        while (count < utfLength) {
+            ch = (int) byteBuffer[count] & 0xff;
+
+            switch (ch & 0xE0) {
+                case 0x00:
+                case 0x10:
+                case 0x20:
+                case 0x30:
+                case 0x40:
+                case 0x50:
+                case 0x60:
+                case 0x70:
+                    /* 0xxxxxxx*/
+                    count++;
+                    charBuffer[charactersRead++] = (char) ch;
+                    break;
+
+                case 0xC0:
+                    /* 110x xxxx   10xx xxxx*/
+                    count += 2;
+
+                    if (count > utfLength) {
+                        throw new IllegalStateException("malformed input: partial character at end");
+                    }
+
+                    ch2 = byteBuffer[count - 1];
+
+                    if ((ch2 & 0xC0) != 0x80) {
+                        throw new IllegalStateException("malformed input around byte " + count);
+                    }
+
+                    charBuffer[charactersRead++] = (char) ((ch & 0x1F) << 6 | ch2 & 0x3F);
+                    break;
+
+                case 0xE0:
+                    /* 1110 xxxx  10xx xxxx  10xx xxxx */
+                    count += 3;
+
+                    if (count > utfLength) {
+                        throw new IllegalStateException("malformed input: partial character at end");
+                    }
+
+                    ch2 = byteBuffer[count - 2];
+                    ch3 = byteBuffer[count - 1];
+
+                    if ((ch2 & 0xC0) != 0x80 || (ch3 & 0xC0) != 0x80) {
+                        throw new IllegalStateException("malformed input around byte " + (count - 1));
+                    }
+
+                    charBuffer[charactersRead++] = (char) ((ch & 0x0F) << 12 |
+                            (ch2 & 0x3F) << 6 |
+                            (ch3 & 0x3F) << 0);
+                    break;
+
+                default:
+                    /* 10xx xxxx,  1111 xxxx */
+                    throw new IllegalStateException("malformed input around byte " + count);
+            }
+        }
+
+        // The number of chars produced may be less than utfLength
+        return new String(charBuffer, 0, charactersRead);
+    }
+
+    public byte readByte() {
+        verifyReadableBytes(1);
+        return _data[_position++];
+    }
+
+    public int readUnsignedByte() {
+        verifyReadableBytes(1);
+        return _data[_position++] & 0xFF;
+    }
+
+    public short readShort() {
+        verifyReadableBytes(2);
+        return (short) ((readUnsignedByte() << 8) +
+                (readUnsignedByte() << 0));
+    }
+
+    public int readUnsignedShort() {
+        verifyReadableBytes(2);
+        return ((readUnsignedByte() << 8) +
+                (readUnsignedByte() << 0));
+    }
+
+    public int readInt() {
+        verifyReadableBytes(4);
+        return (readUnsignedByte() << 24) +
+                (readUnsignedByte() << 16) +
+                (readUnsignedByte() << 8) +
+                (readUnsignedByte() << 0);
+    }
+
+    public long readLong() {
+        verifyReadableBytes(8);
+        return ((long)readUnsignedByte() << 56) +
+                ((long)readUnsignedByte() << 48) +
+                ((long)readUnsignedByte() << 40) +
+                ((long)readUnsignedByte() << 32) +
+                ((long)readUnsignedByte() << 24) +
+                ((long)readUnsignedByte() << 16) +
+                ((long)readUnsignedByte() << 8) +
+                ((long) readUnsignedByte());
+    }
+
+    public float readFloat() {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    public double readDouble() {
+        return Double.longBitsToDouble(readLong());
+    }
+
+    public Buffer writeByte(final int b) {
+        ensureWriteableBytes(1);
+
+        _data[_position++] = (byte) (b & 0xFF);
+
+        return this;
+    }
+
+    public Buffer writeShort(final int s) {
+        ensureWriteableBytes(2);
+
+        _data[_position++] = (byte) ((s >>> 8) & 0xFF);
+        _data[_position++] = (byte) (s & 0xFF);
+
+        return this;
+    }
+
+    public Buffer writeInt(final int i) {
+        ensureWriteableBytes(4);
+
+        _data[_position++] = (byte) ((i >>> 24) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 16) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 8) & 0xFF);
+        _data[_position++] = (byte) (i & 0xFF);
+
+        return this;
+    }
+
+    public Buffer writeLong(final long l) {
+        ensureWriteableBytes(8);
+
+        int i = (int) (l >>> 32);
+
+        _data[_position++] = (byte) ((i >>> 24) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 16) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 8) & 0xFF);
+        _data[_position++] = (byte) (i & 0xFF);
+
+        i = (int) l;
+
+        _data[_position++] = (byte) ((i >>> 24) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 16) & 0xFF);
+        _data[_position++] = (byte) ((i >>> 8) & 0xFF);
+        _data[_position++] = (byte) (i & 0xFF);
+
+        return this;
+    }
+
+    public Buffer writeFloat(final float f) {
+        return writeInt(Float.floatToRawIntBits(f));
+    }
+
+    public Buffer writeDouble(final double d) {
+        return writeLong(Double.doubleToRawLongBits(d));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public Buffer writeUtf8(final String s) {
+        final int charLength = s.length();
+
+        ensureWriteableBytes(2 + charLength);
+
+        // optimistic algorithm: instead of computing the byte length and then
+        // serializing the string (which requires two loops), we assume the byte
+        // length is equal to char length (which is the most frequent case), and
+        // we start serializing the string right away. During the serialization,
+        // if we find that this assumption is wrong, we continue with the
+        // general method.
+        _data[_position++] = (byte) (charLength >>> 8);
+        _data[_position++] = (byte) charLength;
+
+        for (int i = 0; i < charLength; ++i) {
+            char c = s.charAt(i);
+            if (c >= '\001' && c <= '\177') {
+                _data[_position++] = (byte) c;
+            }
+            else {
+                int byteLength = i;
+                for (int j = i; j < charLength; ++j) {
+                    c = s.charAt(j);
+                    if (c >= '\001' && c <= '\177') {
+                        byteLength++;
+                    }
+                    else if (c > '\u07FF') {
+                        byteLength += 3;
+                    }
+                    else {
+                        byteLength += 2;
+                    }
+                }
+
+                _data[_position] = (byte) (byteLength >>> 8);
+                _data[_position + 1] = (byte) byteLength;
+
+                ensureWriteableBytes(2 + byteLength);
+
+                for (int j = i; j < charLength; ++j) {
+                    c = s.charAt(j);
+                    if (c >= '\001' && c <= '\177') {
+                        _data[_position++] = (byte) c;
+                    }
+                    else if (c > '\u07FF') {
+                        _data[_position++] = (byte) (0xE0 | c >> 12 & 0xF);
+                        _data[_position++] = (byte) (0x80 | c >> 6 & 0x3F);
+                        _data[_position++] = (byte) (0x80 | c & 0x3F);
+                    }
+                    else {
+                        _data[_position++] = (byte) (0xC0 | c >> 6 & 0x1F);
+                        _data[_position++] = (byte) (0x80 | c & 0x3F);
+                    }
+                }
+                break;
+            }
+        }
+
+        return this;
+    }
+
+    public Buffer putByteArray(final byte[] b, final int offset, final int length) {
+        ensureWriteableBytes(length);
+        if (b != null) {
+            System.arraycopy(b, offset, _data, _position, length);
+        }
+        _position += length;
+        return this;
+    }
+
+    protected void verifyReadableBytes(final int size) {
+        if (size > 0 && _position + size > _length) {
+            throw new BufferUnderflowException();
+        }
+    }
+
+    protected void ensureWriteableBytes(final int size) {
+        final int minLength = _position + size;
+
+        if (minLength > _data.length) {
+            final int length1 = 2 * _data.length;
+            final int length2 = _position + size;
+
+            _data = Arrays.copyOf(_data, Math.max(length1, length2));
+        }
+
+        _length = Math.max(minLength, _length);
+    }
+}

--- a/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/JarLoader.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/JarLoader.java
@@ -1,0 +1,54 @@
+package com.neva.felix.webconsole.plugins.search.decompiler.jd;
+
+import org.jd.core.v1.api.loader.Loader;
+import org.jd.core.v1.api.loader.LoaderException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class JarLoader implements Loader {
+    private final JarFile _jarFile;
+
+    public JarLoader(final JarFile jarFile) {
+        _jarFile = jarFile;
+    }
+
+    @Override
+    public boolean canLoad(String internalName) {
+        return _jarFile != null && _jarFile.getJarEntry(internalName + ".class") != null;
+    }
+
+    @Override
+    public byte[] load(String internalName) throws LoaderException {
+        Buffer buffer = new Buffer();
+        try {
+
+            final JarEntry entry = _jarFile.getJarEntry(internalName + ".class");
+
+            final InputStream inputStream = _jarFile.getInputStream(entry);
+
+            int remainingBytes = inputStream.available();
+
+            buffer.reset(remainingBytes);
+
+            while (remainingBytes > 0) {
+                final int bytesRead = inputStream.read(buffer.array(), buffer.position(), remainingBytes);
+
+                if (bytesRead < 0) {
+                    break;
+                }
+
+                buffer.position(buffer.position() + bytesRead);
+                remainingBytes -= bytesRead;
+            }
+
+            buffer.position(0);
+
+        } catch (IOException e) {
+            throw new LoaderException(e);
+        }
+        return buffer.array();
+    }
+}

--- a/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/JarLoader.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/JarLoader.java
@@ -8,6 +8,11 @@ import java.io.InputStream;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+/**
+ * @author Mike Strobel
+ * Inspired from code found at https://github.com/mstrobel/procyon.git
+ * com.strobel.assembler.metadata.JarTypeLoader
+ */
 public class JarLoader implements Loader {
     private final JarFile _jarFile;
 

--- a/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/StringPrinter.java
+++ b/src/main/java/com/neva/felix/webconsole/plugins/search/decompiler/jd/StringPrinter.java
@@ -1,0 +1,120 @@
+package com.neva.felix.webconsole.plugins.search.decompiler.jd;
+
+import org.jd.core.v1.api.printer.Printer;
+
+public class StringPrinter implements Printer {
+    protected static final String TAB = "  ";
+    protected static final String NEWLINE = "\n";
+    protected String format;
+    protected int indentationCount = 0;
+    protected StringBuilder sb = new StringBuilder();
+    private boolean displayLineNumbers;
+    private int currentLineNumber = 0;
+
+    @Override
+    public String toString() {
+        return sb.toString();
+    }
+
+    @Override
+    public void start(int maxLineNumber, int majorVersion, int minorVersion) {
+        this.indentationCount = 0;
+        if (maxLineNumber == 0) {
+            format = "%4d";
+        } else {
+            int width = 2;
+
+            while (maxLineNumber >= 10) {
+                width++;
+                maxLineNumber /= 10;
+            }
+
+            format = "%" + width + "d";
+        }
+    }
+
+    @Override
+    public void end() {
+    }
+
+    @Override
+    public void printText(String text) {
+        sb.append(text);
+    }
+
+    @Override
+    public void printNumericConstant(String constant) {
+        sb.append(constant);
+    }
+
+    @Override
+    public void printStringConstant(String constant, String ownerInternalName) {
+        sb.append(constant);
+    }
+
+    @Override
+    public void printKeyword(String keyword) {
+        sb.append(keyword);
+    }
+
+    @Override
+    public void printDeclaration(int type, String internalTypeName, String name, String descriptor) {
+        sb.append(name);
+    }
+
+    @Override
+    public void printReference(int type, String internalTypeName, String name, String descriptor, String ownerInternalName) {
+        sb.append(name);
+    }
+
+    @Override
+    public void indent() {
+        this.indentationCount++;
+    }
+
+    @Override
+    public void unindent() {
+        this.indentationCount--;
+    }
+
+    @Override
+    public void startLine(int lineNumber) {
+        printLineNumber(lineNumber);
+        for (int i = 0; i < indentationCount; i++) sb.append(TAB);
+    }
+
+    @Override
+    public void endLine() {
+        sb.append(NEWLINE);
+    }
+
+    @Override
+    public void extraLine(int count) {
+        while (count-- > 0) sb.append(NEWLINE);
+    }
+
+    @Override
+    public void startMarker(int type) {
+    }
+
+    @Override
+    public void endMarker(int type) {
+    }
+
+    public boolean isDisplayLineNumbers() {
+        return displayLineNumbers;
+    }
+
+    public void setDisplayLineNumbers(boolean displayLineNumbers) {
+        this.displayLineNumbers = displayLineNumbers;
+    }
+
+    protected void printLineNumber(int lineNumber) {
+        if (isDisplayLineNumbers()) {
+            sb.append("/* ");
+            currentLineNumber = lineNumber > 0 ? lineNumber : currentLineNumber + 1;
+            sb.append(String.format(format, currentLineNumber));
+            sb.append(" */ ");
+        }
+    }
+}


### PR DESCRIPTION
jd-core seems to be a much more stable project with lots of unit testing. I added support for output line numbers (can be disabled via configuration of class printer)

All in all I'd say it's better option than cfr, ideally we'd have a dropdown to choose the compiler...